### PR TITLE
Deny s3:ListBucket for s3://get.pulumi.com

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -22,7 +22,7 @@ const contentBucket = new aws.s3.Bucket(`${fullDomain}-bucket`, {
 // contentBucket needs to have the "public-read" ACL so its contents can be ready by CloudFront and
 // served. But we deny the s3:ListBucket permission to prevent unintended disclosure of the bucket's
 // contents.
-const denyListPolicyState: aws.s3.BucketPolicyState = {
+const denyListPolicyState: aws.s3.BucketPolicyArgs = {
     bucket: contentBucket.bucket,
     policy: contentBucket.arn.apply(arn => JSON.stringify({
         Version: "2008-10-17",

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -1,18 +1,13 @@
 {
     "name": "get.pulumi.com",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
         "@types/mime": "^2.0.0",
-        "tslint": "^5.10.0",
-        "typescript": "^2.7.2"
+        "tslint": "^5.12.0",
+        "typescript": "^3.0.0"
     },
     "dependencies": {
-        "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "^0.16.0",
+        "@pulumi/pulumi": "^0.16.0",
         "mime": "^2.3.1"
     }
 }

--- a/infrastructure/yarn.lock
+++ b/infrastructure/yarn.lock
@@ -45,20 +45,39 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@latest":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.16.2.tgz#39b67b6a8807f6f6d75f9cb3e67298310b99e286"
+"@pulumi/aws@^0.16.0":
+  version "0.16.5"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.16.5.tgz#b8c2701b0b43fbf7f105c315134871b4a3036009"
+  integrity sha512-ptV/HK0/yO/sqv1qtQUfoZrxhrPgt+0YurzIUouxj7mhSZvJlyDqmPMdgL/ygQf/rZqGnc2wQs3HclR0XUltVQ==
   dependencies:
-    "@pulumi/pulumi" "^0.16.4"
+    "@pulumi/pulumi" dev
     aws-sdk "^2.0.0"
     builtin-modules "3.0.0"
     mime "^2.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.16.4", "@pulumi/pulumi@latest":
-  version "0.16.6"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.6.tgz#b7341ffb65af75640458acaca63fff47eb9bc640"
+"@pulumi/pulumi@^0.16.0":
+  version "0.16.9"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.9.tgz#addcdeab3bf76ca59729b8617fd39d0cc3f07d50"
+  integrity sha512-FwxHklybzjbMGdhrfZC/1lmZKpAvXx8za7edaLhD1BVKfuFmyFe0xXTSzgTneFAEFFiFlIYySaj/XLXI5MhOgw==
+  dependencies:
+    google-protobuf "^3.5.0"
+    grpc "^1.12.2"
+    minimist "^1.2.0"
+    normalize-package-data "^2.4.0"
+    protobufjs "^6.8.6"
+    read-package-tree "^5.2.1"
+    require-from-string "^2.0.1"
+    source-map-support "^0.4.16"
+    ts-node "^7.0.0"
+    typescript "^3.0.0"
+    upath "^1.1.0"
+
+"@pulumi/pulumi@dev":
+  version "0.16.10-dev.1546573207"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.16.10-dev.1546573207.tgz#555255d0b6ce8284cadef10e2eb547fec8fe0e40"
+  integrity sha512-2n/RQBmeGI4HPXPyurM9XRxg8lxHKHoEP8pYm1Dt1J3gnMCqKwPXVKGzYmNSI+KixzMX3a4kOgoQ9lk+5xol/A==
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -903,9 +922,10 @@ tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
-tslint@^5.10.0:
-  version "5.11.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
+tslint@^5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.12.0.tgz#47f2dba291ed3d580752d109866fb640768fca36"
+  integrity sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"
@@ -925,10 +945,6 @@ tsutils@^2.27.2:
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   dependencies:
     tslib "^1.8.1"
-
-typescript@^2.7.2:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 typescript@^3.0.0:
   version "3.2.1"

--- a/scripts/build-and-deploy
+++ b/scripts/build-and-deploy
@@ -3,7 +3,6 @@ set -eou pipefail
 
 cd infrastructure
 yarn install
-yarn run tsc
 
 case "${TRAVIS_BRANCH}" in
     "master")


### PR DESCRIPTION
The Pulumi program we use to standup a website using S3 and CloudFront makes the S3 bucket's contents world-readable, via the "public-read" ACL. This is required for CloudFront to read data from S3, however, it doesn't follow best practices with regard to security.

The "public-read" ACL includes the `s3:ListBucket` permission, which can be used to enumerate the bucket's contents. For http://get.pulumi.com that isn't a problem, since the whole point of the website is to make the data available. But it doesn't follow best practices.

This PR simply adds a new some bucket policy to deny all users the `s3:ListBucket` permission. (Which also includes people who have read/write access to the bucket; if this becomes a burden we can use a more specific principle.) https://get.pulumi.com should work just like it has before, but if you are using the AWS CLI you won't be able to run `aws s3 ls s3://get.pulumi.com` anymore.