### PR TITLE
Do not require TLS 1.2 on get.pulumi.com

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -74,7 +74,6 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     viewerCertificate: {
         acmCertificateArn: certificateArn,
         sslSupportMethod: "sni-only",
-        minimumProtocolVersion: "TLSv1.2_2018",
     },
     loggingConfig: {
         bucket: logsBucket.bucketDomainName,


### PR DESCRIPTION
PowerShell doesn't support this out of the box, requiring you to utter
something like `[Net.ServicePointManager]::SecurityProtocol =
[Net.SecurityProtocolType]::Tls12` in your PowerShell session before
being able to access it.

We had updated some of our documention to include this information,
but after having folks run into issues since this is pretty
esoteric. To reduce friction against get.pulumi.com, we'll going to
roll back part of the change from #32 to remove this requirement.