### PR TITLE
Be explicit about TLS version

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -74,6 +74,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     viewerCertificate: {
         acmCertificateArn: certificateArn,
         sslSupportMethod: "sni-only",
+        minimumProtocolVersion: "TLSv1_2016",
     },
     loggingConfig: {
         bucket: logsBucket.bucketDomainName,


### PR DESCRIPTION
From experimentation, this is the newest version that works with
PowerShell out of the box.