### PR TITLE
Support 'latest' as a version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
     - node
 install:
-    - curl -fsSL https://get.pulumi.com | bash -s -- --version 0.16.7-dev.1543963592
+    - curl -fsSL https://get.pulumi.com | bash -s
     - export PATH=$HOME/.pulumi/bin:$PATH
 script:
     - ./scripts/build-and-deploy

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -53,7 +53,7 @@ at_exit()
 trap at_exit EXIT
 
 VERSION=""
-if [ "$1" = "--version" ]; then
+if [ "$1" = "--version" ] && [ "$2" != "latest" ]; then
     VERSION=$2
 else
     if ! VERSION=$(curl --fail --silent -L "https://pulumi.io/latest-version"); then


### PR DESCRIPTION
Support passing `--version latest` to get.pulumi.com, in which case using the default behavior of just downloading the latest version.

This feature makes its lightly easier to write parameterized configuration scripts. Since then you don't need to have two separate invocations of `bash`, one with `--version` and one without. ([example](https://github.com/pulumi/circleci/blob/master/orbs/pulumi.yml#L37-L41), [example](https://github.com/pulumi/pulumi/blob/master/dist/docker/Dockerfile#L58-L62))