### PR TITLE
Properly escape $ in message

### DIFF
--- a/dist/install.ps1
+++ b/dist/install.ps1
@@ -62,6 +62,6 @@ Remove-Item -Recurse -Force $tempDir
 
 Write-Host "Pulumi is now installed!"
 Write-Host ""
-Write-Host "Ensure that $binRoot is on your $PATH to use it."
+Write-Host "Ensure that $binRoot is on your `$PATH to use it."
 Write-Host ""
 Write-Host "Get started with Pulumi: https://www.pulumi.com/docs/quickstart"


### PR DESCRIPTION
We accidently dropped the backquote before `$PATH` in one of our
messages. The fact that it is present is not because it is incorrect
markdown formatting, but because it escapes the dollar sign so we print
the literal string `$PATH` in the message instead of failing with an
error saying "The variable '$PATH' cannot be retrieved because it has not
been set."