### PR TITLE
Update CI to use AWS assume role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ install:
     - curl -fsSL https://get.pulumi.com | bash -s
     - export PATH=$HOME/.pulumi/bin:$PATH
 script:
+    - ./scripts/configure-credentials.sh
     - ./scripts/build-and-deploy
 before_install:
+    # Install the AWS CLI.
+    - pip install --upgrade --user awscli
+
     # Install a specific version of node. While this is crazy-old,
     # grpc is supported on it. We should switch to something later
     # when we can do so without any build woes.

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
     - curl -fsSL https://get.pulumi.com | bash -s
     - export PATH=$HOME/.pulumi/bin:$PATH
 script:
-    - ./scripts/configure-credentials.sh
+    - source ./scripts/configure-credentials.sh
     - ./scripts/build-and-deploy
 before_install:
     # Install the AWS CLI.

--- a/scripts/build-and-deploy
+++ b/scripts/build-and-deploy
@@ -19,6 +19,9 @@ esac
 
 pulumi stack select "pulumi/get-pulumi-com-${STACK_NAME}"
 
+echo "Deploying stack 'pulumi/get-pulumi-com-${STACK_NAME}'. Current user:"
+aws sts get-caller-identity
+
 case "${TRAVIS_EVENT_TYPE}" in
     "push")
         pulumi update --yes

--- a/scripts/build-and-deploy
+++ b/scripts/build-and-deploy
@@ -7,13 +7,9 @@ yarn install
 case "${TRAVIS_BRANCH}" in
     "master")
         STACK_NAME="staging"
-        export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID_STAGING}
-        export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY_STAGING}
         ;;
     "production")
         STACK_NAME="production"
-        export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID_PRODUCTION}
-        export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY_PRODUCTION}
         ;;
     *)
         echo "not deploying as TRAVIS_BRANCH is not 'master' or 'production'"

--- a/scripts/configure-credentials.sh
+++ b/scripts/configure-credentials.sh
@@ -62,7 +62,7 @@ readonly CREDS_JSON=$(aws sts assume-role \
 
 export AWS_ACCESS_KEY_ID=$(echo "${CREDS_JSON}"     | jq ".Credentials.AccessKeyId" --raw-output)
 export AWS_SECRET_ACCESS_KEY=$(echo "${CREDS_JSON}" | jq ".Credentials.SecretAccessKey" --raw-output)
-export AWS_SECURITY_TOKEN=$(echo "${CREDS_JSON}"    | jq ".Credentials.SessionToken" --raw-output)
+export AWS_SESSION_TOKEN=$(echo "${CREDS_JSON}"    | jq ".Credentials.SessionToken" --raw-output)
 
 echo "Current AWS identity:"
 aws sts get-caller-identity

--- a/scripts/configure-credentials.sh
+++ b/scripts/configure-credentials.sh
@@ -3,11 +3,8 @@
 # Set the environment variables to use the right AWS account/identity
 # based on the current branch.
 
-set -o nounset -o errexit -o pipefail
-
 if [ -z "${TRAVIS_BRANCH:-}" ]; then
     echo "WARNING: TRAVIS_BRANCH not set. Aborting."
-    return
 fi
 
 # When running on CI, which stack should we update? (And as a result, which

--- a/scripts/configure-credentials.sh
+++ b/scripts/configure-credentials.sh
@@ -35,7 +35,8 @@ case ${TRAVIS_BRANCH} in
         export AWS_ASSUME_ROLE_ARN="${CI_PRODUCTION_ROLE_ARN}"
         ;;
     *)
-        echo "WARNING: Did not recognize TRAVIS_BRANCH (${TRAVIS_BRANCH}), not assuming AWS IAM Role."
+        echo "WARNING: Did not recognize TRAVIS_BRANCH (${TRAVIS_BRANCH}), defaulting to staging."
+        export AWS_ASSUME_ROLE_ARN="${CI_STAGING_ROLE_ARN}"
         ;;
 esac
 

--- a/scripts/configure-credentials.sh
+++ b/scripts/configure-credentials.sh
@@ -55,5 +55,14 @@ echo "AWS credentials           :"
 echo "AWS_ACCESS_KEY_ID         : ${AWS_ACCESS_KEY_ID}"
 echo "AWS_ASSUME_ROLE_ARN       : ${AWS_ASSUME_ROLE_ARN}"
 
+# Go and try to assume the role.
+readonly CREDS_JSON=$(aws sts assume-role \
+                 --role-arn "${AWS_ASSUME_ROLE_ARN}" \
+                 --role-session-name "get.pulumi.com-travis-job-${TRAVIS_JOB_NUMBER}")
+
+export AWS_ACCESS_KEY_ID=$(echo "${CREDS_JSON}"     | jq ".Credentials.AccessKeyId" --raw-output)
+export AWS_SECRET_ACCESS_KEY=$(echo "${CREDS_JSON}" | jq ".Credentials.SecretAccessKey" --raw-output)
+export AWS_SECURITY_TOKEN=$(echo "${CREDS_JSON}"    | jq ".Credentials.SessionToken" --raw-output)
+
 echo "Current AWS identity:"
 aws sts get-caller-identity

--- a/scripts/configure-credentials.sh
+++ b/scripts/configure-credentials.sh
@@ -1,0 +1,61 @@
+#! /bin/bash
+#
+# Set the environment variables to use the right AWS account/identity
+# based on the current branch.
+
+set -o nounset -o errexit -o pipefail
+
+if [ -z "${TRAVIS_BRANCH:-}" ]; then
+    echo "WARNING: TRAVIS_BRANCH not set. Aborting."
+    return
+fi
+
+# When running on CI, which stack should we update? (And as a result, which
+# set of credentials should we be using?)
+#
+# Using TRAVIS_BRANCH "just works in most cases. For "push" jobs directly
+# to "staging" or "production" will target the right environment, otherwise
+# will default to testing for pushes to "master" or feature branches.
+# (Since for "push" jobs TRAVIS_BRANCH is the name of the branch pushed to.)
+#
+# If the Travis job type is "pull_request", then we want the environment to
+# target to match the branch the pull request will be merged _into_. For
+# example, a pull request to be merged into the staging branch should target
+# the staging environment. (For "pull_request" jobs TRAVIS_BRANCH is the name
+# of the branch targeted in the pull request.)
+#
+# For pushes to other topic branches (e.g. "joe/feature-x") we don't do anything,
+# since we don't expect to be touching cloud resources.
+
+export AWS_ACCESS_KEY_ID="${CI_AWS_ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${CI_AWS_SECRET_ACCESS_KEY}"
+
+case ${TRAVIS_BRANCH} in
+    master)
+        export AWS_ASSUME_ROLE_ARN="${CI_STAGING_ROLE_ARN}"
+        ;;
+    production)
+        export AWS_ASSUME_ROLE_ARN="${CI_PRODUCTION_ROLE_ARN}"
+        ;;
+    *)
+        echo "WARNING: Did not recognize TRAVIS_BRANCH (${TRAVIS_BRANCH}), not assuming AWS IAM Role."
+        ;;
+esac
+
+# Create a default config for AWS
+aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+aws configure set region "${AWS_REGION:-us-west-2}"
+
+echo "Travis information         :"
+echo "TRAVIS_BRANCH              : ${TRAVIS_BRANCH}"
+echo "TRAVIS_EVENT_TYPE          : ${TRAVIS_EVENT_TYPE}"
+echo "TRAVIS_JOB_NUMBER          : ${TRAVIS_JOB_NUMBER}"
+echo "TRAVIS_PULL_REQUEST_BRANCH : ${TRAVIS_PULL_REQUEST_BRANCH}"
+
+echo "AWS credentials           :"
+echo "AWS_ACCESS_KEY_ID         : ${AWS_ACCESS_KEY_ID}"
+echo "AWS_ASSUME_ROLE_ARN       : ${AWS_ASSUME_ROLE_ARN}"
+
+echo "Current AWS identity:"
+aws sts get-caller-identity

--- a/scripts/configure-credentials.sh
+++ b/scripts/configure-credentials.sh
@@ -4,7 +4,7 @@
 # based on the current branch.
 
 if [ -z "${TRAVIS_BRANCH:-}" ]; then
-    echo "WARNING: TRAVIS_BRANCH not set. Aborting."
+    echo "WARNING: TRAVIS_BRANCH not set."
 fi
 
 # When running on CI, which stack should we update? (And as a result, which


### PR DESCRIPTION
We no longer have the ability to update [pulumi/get.pulumi.com/get-pulumi-com-production](https://app.pulumi.com/pulumi/get-pulumi-com/get-pulumi-com-production) because the Travis CI was configured to use an AWS IAM Access Key (`AKIAJ6HACOW5X6VGMQHA`) that no longer exists.

I'm fairly sure I deleted this myself the last time I was reviewing up our security setup. Rather than create a new IAM User to replace it (which is an anti-pattern), this PR updates our CI scripts to use a lower privilege AWS account and then assume role into staging/production as needed to update the stack.

This is done using a Bash script mostly cribbed from the Pulumi Service repo. I already went ahead and updated all the [Travis CI settings](https://travis-ci.com/github/pulumi/get.pulumi.com/settings) for the project. Adding the new environment variables:

- `CI_AWS_ACCESS_KEY_ID`
- `CI_AWS_SECRET_ACCESS_KEY`
- `CI_STAGING_ROLE_ARN`
- `CI_PRODUCTION_ROLE_ARN`

The low privilege IAM User credentials that are being used is for a new [get-pulumi-com-ci](https://console.aws.amazon.com/iam/home?#/users/get-pulumi-com-ci) user I just created. It was essentially cloned from the `pulumi-service-ci` user. Here's it's relevant configuration:

- Copied the IAM Policy attachments from `pulumi-service-ci` (allowing it to assume-role elsewhere).
- Tags:
   - Owner: chris
    - do-not-delete: ""
    - Home: https://github.com/pulumi/get.pulumi.com/


Assuming I got everything right, this should "just work" and update the staging stack when this gets merged into `master`, and production when we merge into `production`.

LMK if there is anything I missed in setting this up.