### PR TITLE
Add IAM Role for CI users to upload releases

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -46,6 +46,73 @@ aws.getCallerIdentity().then((callerIdentity) => {
     const denyListPolicy = new aws.s3.BucketPolicy("deny-list", denyListPolicyState);
 });
 
+// IAM Role available to CI/CD bots to allow them to upload binaries as part of the release process.
+// Previously we copied them to s3://rel.pulumi.com, but we later changed to uploading the binaries
+// directly to s3://get.pulumi.com.
+const uploadReleaseRole = new aws.iam.Role("PulumiUploadRelease", {
+    name: "PulumiUploadRelease",
+    description: "Upload new releases of the Pulumi SDK to get.pulumi.com.",
+    assumeRolePolicy: {
+        Version: "2012-10-17",
+        Statement: [
+            {
+                Effect: "Allow",
+                Principal: {
+                    AWS: [
+                        // Pulumi CI AWS account. The IAM User we use for CI will need to be
+                        // give permissions to assume this role.
+                        "arn:aws:iam::894850187425:root",
+                    ],
+                },
+                Action: "sts:AssumeRole",
+                // Block assuming this role unless the external ID matches the following. This
+                // isn't a security measure so much as a double-checking intent.
+                Condition: {
+                    StringEquals: {
+                        "sts:ExternalId": [
+                            "upload-pulumi-release"
+                        ],
+                    },
+                },
+            },
+        ],
+    },
+    tags: {
+        "stack": pulumi.getStack(),
+    },
+});
+
+// ARN of the role we need to hook up to our CI bots to enable them to upload releases.
+export const uploadReleaseRoleArn = uploadReleaseRole.arn;
+
+// Permissions granted to those who assume the upload releases role.
+const uploadReleasePolicy = new aws.iam.Policy("PulumiUploadReleasePolicy", {
+    name: "PulumiUploadReleasePolicy",
+    description: "Upload Pulumi ",
+    policy: {
+        Version: "2012-10-17",
+        Statement: [
+            {
+                Effect: "Allow",
+                // Only allow uploading data. So `aws s3 cp` or `aws s3 ls` won't work.
+                Action: [
+                    "s3:PutObject",
+                    "s3:PutObjectAcl",
+                ],
+                // Only allow uploading objects with certain prefixes.
+                Resource: [
+                    pulumi.interpolate`${contentBucket.arn}/releases/plugins/*`,
+                    pulumi.interpolate`${contentBucket.arn}/releases/sdk/*`,
+                ],
+            },
+        ],
+    },
+});
+
+const rolePolicyAttachment = new aws.iam.RolePolicyAttachment("PulumiUploadReleasePolicyAttachment", {
+    role: uploadReleaseRole,
+    policyArn: uploadReleasePolicy.arn,
+});
 
 const logsBucket = new aws.s3.Bucket(`${fullDomain}-logs`, {
     acl: "log-delivery-write",
@@ -97,7 +164,7 @@ const cloudfront = new aws.cloudfront.Distribution(`${fullDomain}-cf`, distribut
 const record = new aws.route53.Record(`${fullDomain}-record`, {
     name: subDomain,
     type: "A",
-    zoneId: aws.route53.getZone({name: domain}).then(x => x.zoneId),
+    zoneId: aws.route53.getZone({ name: domain }).then(x => x.zoneId),
     aliases: [
         {
             name: cloudfront.domainName,


### PR DESCRIPTION
This PR updates the `get.pulumi.com` stack to define a new IAM Role named `PulumiUploadRelease` that will grant write-only access to s3://get.pulumi.com/releases/{plugins, sdk}/`. We will migrate our CI and releases process to start using this role instead of the similar `UploadPulumiReleases` IAM Role.

The reason to introduce a new role when `UploadPulumiReleases` is already sufficient is because:

- The existing role is too broad, granting access to `s3:*` to both `s3://rel.pulumi.com` and `s3://get.pulumi.com`. (Also, both the bucket and any objects within it.)
- This newer rule is much more narrow in scope, which would prevent various potential vectors of abuse.
- The existing role was created manually, and therefore not tracked by any "code" and/or code review process. Whereas now, the stack that creates the `s3://get.pulumi.com` bucket also defines the extent to which outside-accounts can access it. (Which seems like the most natural place to put it.)

I've already updated the `pulumi/get.pulumi.com/production` stack and the new role ARN is - I've already updated the `pulumi/get.pulumi.com/production` stack, and the new ARN is `arn:aws:iam::058607598222:role/PulumiUploadRelease`. I'll start testing updating our provider repo's publishing scripts to confirm everything is on the up and up. If so, then we'll be able to start serving those releases via a CDN directly from https://get.pulumi.com/ instead of https://api.pulumi.com/.

For a more detailed description of how this fits into the overall scheme of things, see: https://github.com/pulumi/pulumi-service/issues/3068#issuecomment-626878731
