### PR TITLE
Update the trust policy to allow sts:TagSession

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -87,7 +87,7 @@ const uploadReleaseRole = new aws.iam.Role("PulumiUploadRelease", {
         ],
     },
     tags: {
-        "stack": pulumi.getStack(),
+        "stack": `${pulumi.getProject()}/${pulumi.getStack()}`,
     },
 });
 

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -74,6 +74,16 @@ const uploadReleaseRole = new aws.iam.Role("PulumiUploadRelease", {
                     },
                 },
             },
+            // Allow the assumer to also set session tags.
+            {
+                Effect: "Allow",
+                Principal: {
+                    AWS: [
+                        "arn:aws:iam::318722933755:root",
+                    ],
+                },
+                Action: "sts:TagSession",
+            }
         ],
     },
     tags: {


### PR DESCRIPTION
Update the IAM Role we use allowing our CI users to upload Pulumi releases, to also use the `sts:TagSession` action. Evidently it's really important that the trust policy puts the `sts:TagSession` in a separate statement, without a condition on it.

I also updated the tag we put on the role, since the stack name is `production` which isn't s super-useful. Now it will be `get.pulumi.com/production`.

I've manually deployed these changes to production, so @jaxxstorm you can try rerunning the Goreleaser tool to upload releases using the `PulumiUploadRelease` role.