### PR TITLE
Update CDN settings

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -140,9 +140,13 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         },
         targetOriginId: contentBucket.bucketDomainName.apply(d => `S3-${d}`),
         viewerProtocolPolicy: "redirect-to-https",
+
+        // TTLs. These are used since presumably there aren't any cache control settings
+        // for the individual S3 objects.
         minTtl: 0,
-        defaultTtl: 60,
-        maxTtl: 60,
+        defaultTtl: 604800,  // One week.
+        maxTtl: 31536000,  // One year, the default.
+
         compress: true,
     },
     enabled: true,
@@ -150,6 +154,10 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
         domainName: contentBucket.bucketDomainName,
         originId: contentBucket.bucketDomainName.apply(d => `S3-${d}`),
     }],
+    // Cache content from all CloudFront edge locations, meaning it will have the
+    // best performance. Other price classes restrict some locations, which means
+    // you would pay less for hosting the CDN.
+    priceClass: "PriceClass_All",
     restrictions: {
         geoRestriction: {
             restrictionType: "none",


### PR DESCRIPTION
Now that we did all the work to serve plugins from https://get.pulumi.com, the final step is to double-check that we have configured CloudFront correctly.

Taking a look just now, only two things needed to be touched:

- The Default TTL we sent was way too short. We were only caching things for a minute. I set this to a full week, which might be too high TBH. (For reference, the default is one day; LMK what you think.)
- The default for price class is "all", meaning serve the content from all edge locations. (And I confirmed that's the case by looking at our checkpoint file right now.) But I updated the code to make it explicit.