### PR TITLE
Add a note about third-party usage of latest-version

### DIFF
--- a/dist/install.ps1
+++ b/dist/install.ps1
@@ -4,6 +4,15 @@ $ProgressPreference="SilentlyContinue"
 
 # Some versions of PowerShell do not support Tls1.2 out of the box, but pulumi.com requires it
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# Query pulumi.com/latest-version for the most recent release. Because this approach
+# is now used by third parties as well (e.g., GitHub Actions virtual environments),
+# changes to this API should be made with care to avoid breaking any services that
+# rely on it (and ideally be accompanied by PRs to update them accordingly). Known
+# consumers of this API include:
+#
+# * https://github.com/actions/virtual-environments
+#
 $latestVersion = (Invoke-WebRequest -UseBasicParsing https://www.pulumi.com/latest-version).Content.Trim()
 
 $downloadUrl = "https://get.pulumi.com/releases/sdk/pulumi-v${latestVersion}-windows-x64.zip"
@@ -49,7 +58,7 @@ try {
         Write-Host "Added $binRoot to the $PATH. Changes may not be visible until after a restart."
     }
     $envKey.Close();
-} catch { 
+} catch {
 }
 
 if ($env:PATH -notlike "*$binRoot*") {

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -73,6 +73,16 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "${VERSION}" ]; then
+
+    # Query pulumi.com/latest-version for the most recent release. Because this approach
+    # is now used by third parties as well (e.g., GitHub Actions virtual environments),
+    # changes to this API should be made with care to avoid breaking any services that
+    # rely on it (and ideally be accompanied by PRs to update them accordingly). Known
+    # consumers of this API include:
+    #
+    # * https://github.com/actions/virtual-environments
+    #
+
     if ! VERSION=$(curl --fail --silent -L "https://www.pulumi.com/latest-version"); then
         >&2 say_red "error: could not determine latest version of Pulumi, try passing --version X.Y.Z to"
         >&2 say_red "       install an explicit version"


### PR DESCRIPTION
This change just adds a couple of comments to our install scripts to be careful about making changes to the way we determine the latest version of Pulumi, since some third-party services, such as [GitHub Actions](https://github.com/actions/virtual-environments), now rely on it.