### PR TITLE
set ACL on SDK directory

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -48,6 +48,13 @@ aws.getCallerIdentity().then((callerIdentity) => {
                     Action: ["s3:GetObject"],
                     Resource: [`${arn}/releases/plugins/*`],
                 },
+                {
+                    Sid: "SDKPublicRead",
+                    Effect: "Allow",
+                    Principal: "*",
+                    Action: ["s3:GetObject"],
+                    Resource: [`${arn}/releases/sdk/*`],
+                }
             ],
         })),
     };


### PR DESCRIPTION
Switching uploads for pulumi/pulumi to goreleaser, so we need to have
publicread on this SDK bucket directory too