### PR TITLE
Revert "fix shellcheck"

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -47,9 +47,6 @@ say_white()
 
 at_exit()
 {
-    # shellcheck disable=SC2181
-    # https://github.com/koalaman/shellcheck/wiki/SC2181
-    # Disable because we don't actually know the command we're running
     if [ "$?" -ne 0 ]; then
         >&2 say_red
         >&2 say_red "We're sorry, but it looks like something might have gone wrong during installation."
@@ -120,7 +117,7 @@ say_white "+ Downloading ${TARBALL_URL}..."
 
 TARBALL_DEST=$(mktemp -t pulumi.tar.gz.XXXXXXXXXX)
 
-if curl --fail "$(printf %s "${SILENT}")" -L -o "${TARBALL_DEST}" "${TARBALL_URL}"; then
+if curl --fail $(printf %s "${SILENT}") -L -o "${TARBALL_DEST}" "${TARBALL_URL}"; then
     say_white "+ Extracting to $HOME/.pulumi/bin"
 
     # If `~/.pulumi/bin exists, clear it out
@@ -184,7 +181,7 @@ if ! command -v pulumi >/dev/null; then
             ;;
     esac
 
-    if [ -n "${PROFILE_FILE}" ]; then
+    if [ ! -z "${PROFILE_FILE}" ]; then
         LINE_TO_ADD="export PATH=\$PATH:\$HOME/.pulumi/bin"
         if ! grep -q "# add Pulumi to the PATH" "${PROFILE_FILE}"; then
             say_white "+ Adding \$HOME/.pulumi/bin to \$PATH in ${PROFILE_FILE}"


### PR DESCRIPTION
This reverts commit bce5f53d05e8820c4395586f7286ca17b6604491.

(We suspect this change may be causing some users to have trouble downloading Pulumi.)