### PR TITLE
Unquote an optional curl argument (#90)

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -120,7 +120,11 @@ say_white "+ Downloading ${TARBALL_URL}..."
 
 TARBALL_DEST=$(mktemp -t pulumi.tar.gz.XXXXXXXXXX)
 
-if curl --fail "$(printf %s "${SILENT}")" -L -o "${TARBALL_DEST}" "${TARBALL_URL}"; then
+# shellcheck disable=SC2181
+# shellcheck disable=SC2046
+# https://github.com/koalaman/shellcheck/wiki/SC2181
+# Disable to allow the `--silent` option to be omitted.
+if curl --fail $(printf %s "${SILENT}") -L -o "${TARBALL_DEST}" "${TARBALL_URL}"; then
     say_white "+ Extracting to $HOME/.pulumi/bin"
 
     # If `~/.pulumi/bin exists, clear it out


### PR DESCRIPTION
* Unquote an optional curl argumement
* ignore multiple shellcheck errors

Co-authored-by: Lee Briggs <lee@leebriggs.co.uk>