### PR TITLE
Fix the shellcheck reference, fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
 # get.pulumi.com
 
-This is the infrastrcture that powers `https://get.pulumi.com`, our download
-page.
-
-The infrastructure is deployed via
-[Pulumi.com](https://pulumi.com/pulumi/get-pulumi-com-production) itself.
+This is the infrastructure that powers `https://get.pulumi.com`, our download page.

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -120,9 +120,8 @@ say_white "+ Downloading ${TARBALL_URL}..."
 
 TARBALL_DEST=$(mktemp -t pulumi.tar.gz.XXXXXXXXXX)
 
-# shellcheck disable=SC2181
 # shellcheck disable=SC2046
-# https://github.com/koalaman/shellcheck/wiki/SC2181
+# https://github.com/koalaman/shellcheck/wiki/SC2046
 # Disable to allow the `--silent` option to be omitted.
 if curl --fail $(printf %s "${SILENT}") -L -o "${TARBALL_DEST}" "${TARBALL_URL}"; then
     say_white "+ Extracting to $HOME/.pulumi/bin"


### PR DESCRIPTION
Turns out we only need one of these, so this fixes that up, and also fixes a typo and removes some no-longer-accurate info in the README.