### PR TITLE
Add support to install Pulumi on AWS Graviton devices

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -107,6 +107,7 @@ ARCH=""
 case $(uname -m) in
     "x86_64") ARCH="x64";;
     "arm64") ARCH="arm64";;
+    "aarch64") ARCH="arm64";;
     *)
         print_unsupported_platform
         exit 1


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/6745

```
ubuntu@ip-172-31-36-233:~$ uname -m
aarch64
```

before:

```
ubuntu@ip-172-31-36-233:~$ ./install.sh
error: We're sorry, but it looks like Pulumi is not supported on your platform
       We support 64-bit versions of Linux and macOS and are interested in supporting
       more platforms.  Please open an issue at https://github.com/pulumi/pulumi and
       let us know what platform you're using!

We're sorry, but it looks like something might have gone wrong during installation.
If you need help, please join us on https://slack.pulumi.com/
```

after:

```
ubuntu@ip-172-31-36-233:~$ ./install.sh
=== Installing Pulumi v2.24.1 ===
+ Downloading https://get.pulumi.com/releases/sdk/pulumi-v2.24.1-linux-arm64.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 57.2M  100 57.2M    0     0  13.6M      0  0:00:04  0:00:04 --:--:-- 13.6M
+ Extracting to /home/ubuntu/.pulumi/bin
+ Adding $HOME/.pulumi/bin to $PATH in /home/ubuntu/.bashrc

=== Pulumi is now installed! 🍹 ===
+ Please restart your shell or add /home/ubuntu/.pulumi/bin to your $PATH
+ Get started with Pulumi: https://www.pulumi.com/docs/quickstart
ubuntu@ip-172-31-36-233:~$ ~/.pulumi/bin/pulumi version
v2.24.1
```