### PR TITLE
Use Yarn

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -57,7 +57,7 @@ jobs:
         role-external-id: "pulumi/get-pulumi-com/staging"
         role-duration-seconds: 3600
         role-session-name: get.pulumi.com-${{ github.run_id }}
-    - run: npm install
+    - run: yarn install
       working-directory: infrastructure
     - uses: pulumi/actions@v3
       with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -55,7 +55,7 @@ jobs:
         role-external-id: "pulumi/get-pulumi-com/production"
         role-duration-seconds: 3600
         role-session-name: get.pulumi.com-${{ github.run_id }}
-    - run: npm install
+    - run: yarn install
       working-directory: infrastructure
     - uses: pulumi/actions@v3
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -45,7 +45,7 @@ jobs:
       uses: pulumi/action-install-pulumi-cli@v1
     - if: github.ref == 'refs/heads/production'
       run: |
-          echo "AWS_ROLE_TO_ASSUME=${{ secrets.AWS_ROLE_TO_ASSUME_PRODUCTION }}" >> $GITHUB_ENV      
+          echo "AWS_ROLE_TO_ASSUME=${{ secrets.AWS_ROLE_TO_ASSUME_PRODUCTION }}" >> $GITHUB_ENV
     - uses: actions/checkout@v2
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -57,7 +57,7 @@ jobs:
         role-external-id: ${{ env.PULUMI_STACK_NAME }}
         role-duration-seconds: 3600
         role-session-name: get.pulumi.com-${{ github.run_id }}
-    - run: npm install
+    - run: yarn install
       working-directory: infrastructure
     - if: github.ref == 'refs/heads/production'
       uses: pulumi/actions@v3


### PR DESCRIPTION
Since it looks like we have a `yarn.lock` file in infrastrucure, and we generally prefer Yarn over npm, use `yarn` instead of `npm` in this repo's GHA workflows as well.