### PR TITLE
Bump the minimum protocol version policy to a more modern one.

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -232,7 +232,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     viewerCertificate: {
         acmCertificateArn: certificateArn,
         sslSupportMethod: "sni-only",
-        minimumProtocolVersion: "TLSv1_2016",
+        minimumProtocolVersion: "TLSv1.2_2018",
     },
     loggingConfig: {
         bucket: logsBucket.bucketDomainName,


### PR DESCRIPTION
See also https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html