### PR TITLE
Pin actions versions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+      uses: ludeeus/action-shellcheck@1.1.0
       with:
         scandir: "./dist"
   install:
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install chef
-      uses: actionshub/chef-install@master
+      uses: actionshub/chef-install@1.1.0
       with:
         channel: current
         project: inspec

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+      uses: ludeeus/action-shellcheck@1.1.0
       with:
         scandir: "./dist"
   install:
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install chef
-      uses: actionshub/chef-install@master
+      uses: actionshub/chef-install@1.1.0
       with:
         channel: current
         project: inspec


### PR DESCRIPTION
Sillily, I noticed that we should pin the action versions in my previous PR, but failed to update the workflows for staging and production. This fixes that.