### PR TITLE
Add exponential backoff for `curl`

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -86,7 +86,7 @@ if [ -z "${VERSION}" ]; then
     # * https://github.com/actions/virtual-environments
     #
 
-    if ! VERSION=$(curl --fail --silent -L "https://www.pulumi.com/latest-version"); then
+    if ! VERSION=$(curl --retry 3 --fail --silent -L "https://www.pulumi.com/latest-version"); then
         >&2 say_red "error: could not determine latest version of Pulumi, try passing --version X.Y.Z to"
         >&2 say_red "       install an explicit version"
         exit 1
@@ -129,7 +129,7 @@ TARBALL_DEST=$(mktemp -t pulumi.tar.gz.XXXXXXXXXX)
 # shellcheck disable=SC2046
 # https://github.com/koalaman/shellcheck/wiki/SC2046
 # Disable to allow the `--silent` option to be omitted.
-if curl --fail $(printf %s "${SILENT}") -L -o "${TARBALL_DEST}" "${TARBALL_URL}"; then
+if curl --retry 3 --fail $(printf %s "${SILENT}") -L -o "${TARBALL_DEST}" "${TARBALL_URL}"; then
     say_white "+ Extracting to $HOME/.pulumi/bin"
 
     # If `~/.pulumi/bin exists, clear it out

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -157,7 +157,7 @@ if curl --retry 3 --fail $(printf %s "${SILENT}") -L -o "${TARBALL_DEST}" "${TAR
     rm -rf "${EXTRACT_DIR}"
 else
     >&2 say_red "error: failed to download ${TARBALL_URL}"
-    >&2 say_red "       please check your internet and try again, if the problem persists then file an"
+    >&2 say_red "       check your internet and try again; if the problem persists, file an"
     >&2 say_red "       issue at https://github.com/pulumi/pulumi/issues/new/choose"
     exit 1
 fi

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -157,6 +157,8 @@ if curl --retry 3 --fail $(printf %s "${SILENT}") -L -o "${TARBALL_DEST}" "${TAR
     rm -rf "${EXTRACT_DIR}"
 else
     >&2 say_red "error: failed to download ${TARBALL_URL}"
+    >&2 say_red "       please check your internet and try again, if the problem persists then file an"
+    >&2 say_red "       issue at https://github.com/pulumi/pulumi/issues/new/choose"
     exit 1
 fi
 


### PR DESCRIPTION
`curl` will hit it's endpoint up to 3 times. See the `curl` man page for details:
> If a transient error is returned when curl tries to perform a
              transfer, it will retry this number of times before giving up.
              Setting the number to 0 makes curl do no retries (which is the
              default). Transient error means either: a timeout, an FTP 4xx
              response code or an HTTP 408, 429, 500, 502, 503 or 504 response
              code.

Fixes #129 