### PR TITLE
Support shallower .zip installation

### DIFF
--- a/dist/install.ps1
+++ b/dist/install.ps1
@@ -54,7 +54,12 @@ if (Test-Path -Path $binRoot) {
 }
 
 New-Item $pulumiInstallRoot -ItemType Directory -Force | Out-Null
-Move-Item (Join-Path $tempDir (Join-Path "pulumi" "bin")) $pulumiInstallRoot
+if (Test-Path (Join-Path $tempDir (Join-Path "pulumi" "bin"))) {
+    Move-Item (Join-Path $tempDir (Join-Path "pulumi" "bin")) $pulumiInstallRoot
+} else {
+    Move-Item (Join-Path $tempDir "pulumi") $binRoot
+}
+
 
 # Attempt to add ourselves to the $PATH, but if we can't, don't fail the overall script.
 try {


### PR DESCRIPTION
If the .zip structure is `pulumi/bin/*.exe`, as in 3.36.0 and below, installation proceeds as before.

If the .zip is `pulumi/*.exe`, as in 3.37.0, installation handles that case and copies the exe files to the bin dir.