### PR TITLE
Add `pulumi-provider-build-environment` to list of ECR repos

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -144,6 +144,7 @@ const productionImageRepositories = [
     "pulumi-python",
     "pulumi-kubernetes-operator",
     "pulumi-base",
+    "pulumi-provider-build-environment",
 ].map(repo => `arn:aws:ecr-public::058607598222:repository/${repo}`);
 
 // Allow uploading to the production release repositories.


### PR DESCRIPTION
We've been publishing the `pulumi-provider-build-environment` image to https://hub.docker.com/r/pulumi/pulumi-provider-build-environment, but our sync from Docker Hub to ECR has been failing because the `pulumi-provider-build-environment` repository hasn't existed in ECR.

We've now manually created the [`pulumi-provider-build-environment`](https://gallery.ecr.aws/pulumi/pulumi-provider-build-environment) repo.

This change includes it in the list so it gets the appropriate policies to allow us to publish to it.

Part of https://github.com/pulumi/pulumi-docker-containers/issues/122