### PR TITLE
Use github releases before falling back to S3

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -129,7 +129,11 @@ TARBALL_DEST=$(mktemp -t pulumi.tar.gz.XXXXXXXXXX)
 download_tarball() {
 # Try to download from github first, then fallback to get.pulumi.com
     say_white "+ Downloading ${TARBALL_URL}${TARBALL_PATH}..."
-    if ! curl --fail ${SILENT} -L -o "${TARBALL_DEST}" "${TARBALL_URL}${TARBALL_PATH}"; then
+    # This should opportunistically use the GITHUB_TOKEN to avoid rate limiting
+    # ...I think. It's hard to test accurately. But it at least doesn't seem tohurt.
+    if ! curl --fail ${SILENT} -L \
+        --header "Authorization: Bearer $GITHUB_TOKEN" \
+        -o "${TARBALL_DEST}" "${TARBALL_URL}${TARBALL_PATH}"; then
         say_white "+ Error encountered, falling back to ${TARBALL_URL_FALLBACK}${TARBALL_PATH}..."
         if ! curl --retry 2 --fail ${SILENT} -L -o "${TARBALL_DEST}" "${TARBALL_URL_FALLBACK}${TARBALL_PATH}"; then
             return 1

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -127,10 +127,10 @@ fi
 TARBALL_DEST=$(mktemp -t pulumi.tar.gz.XXXXXXXXXX)
 
 download_tarball() {
-# Try to download from github first, then fallback to get.pulumi.com
+    # Try to download from github first, then fallback to get.pulumi.com
     say_white "+ Downloading ${TARBALL_URL}${TARBALL_PATH}..."
     # This should opportunistically use the GITHUB_TOKEN to avoid rate limiting
-    # ...I think. It's hard to test accurately. But it at least doesn't seem tohurt.
+    # ...I think. It's hard to test accurately. But it at least doesn't seem to hurt.
     if ! curl --fail ${SILENT} -L \
         --header "Authorization: Bearer $GITHUB_TOKEN" \
         -o "${TARBALL_DEST}" "${TARBALL_URL}${TARBALL_PATH}"; then


### PR DESCRIPTION
Tested the fallback by manually breaking the first url
```
+ Downloading https://github.com/pulumi/pulumi/releases/download/v3.73.0/xxpulumi-v3.73.0-darwin-arm64.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     9    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
+ Error encountered, falling back to https://get.pulumi.com/releases/sdk/pulumi-v3.73.0-darwin-arm64.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
 13  129M   13 17.9M    0     0  5599k      0  0:00:23  0:00:03  0:00:20 5608k^C%                     
 ```
 
 Also tested that the behavior of `--silent` supplied to the script works properly.
 
 Ran script with both my `/bin/sh` (bash, presumably in emulation mode) and `zsh` with `emulate sh -c "./install.sh"`