### PR TITLE
allow getting latest dev version from get.pulumi.com

### DIFF
--- a/dist/install.ps1
+++ b/dist/install.ps1
@@ -9,6 +9,11 @@ $ProgressPreference="SilentlyContinue"
 # Some versions of PowerShell do not support Tls1.2 out of the box, but pulumi.com requires it
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
+if ($Version -eq "dev") {
+    $latestVersion = (Invoke-WebRequest -UseBasicParsing https://www.pulumi.com/latest-dev-version).Content.Trim()
+    $Version = $latestVersion
+}
+
 if ($Version -eq $null -or $Version -eq "") {
     # Query pulumi.com/latest-version for the most recent release. Because this approach
     # is now used by third parties as well (e.g., GitHub Actions virtual environments),

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -76,6 +76,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "${VERSION}" = "dev" ]; then
+    IS_DEV_VERSION=true
     if ! VERSION=$(curl --retry 3 --fail --silent -L "https://www.pulumi.com/latest-dev-version"); then
         >&2 say_red "error: could not determine latest dev version of Pulumi, try passing --version X.Y.Z to"
         >&2 say_red "       install an explicit version, or no argument to get the latest release version"
@@ -135,6 +136,15 @@ fi
 TARBALL_DEST=$(mktemp -t pulumi.tar.gz.XXXXXXXXXX)
 
 download_tarball() {
+    # If we're installing a dev version, we need to use the s3 URL,
+    # as the version is not uploaded to GitHub releases
+    if [ "$IS_DEV_VERSION" = "true" ]; then
+        say_white "+ Downloading ${TARBALL_URL_FALLBACK}${TARBALL_PATH}..."
+        if ! curl --retry 2 --fail ${SILENT} -L -o "${TARBALL_DEST}" "${TARBALL_URL_FALLBACK}${TARBALL_PATH}"; then
+            return 1
+        fi
+	return 0
+    fi
     # Try to download from github first, then fallback to get.pulumi.com
     say_white "+ Downloading ${TARBALL_URL}${TARBALL_PATH}..."
     # This should opportunistically use the GITHUB_TOKEN to avoid rate limiting

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -75,6 +75,14 @@ while [ $# -gt 0 ]; do
      shift
 done
 
+if [ "${VERSION}" = "dev" ]; then
+    if ! VERSION=$(curl --retry 3 --fail --silent -L "https://www.pulumi.com/latest-dev-version"); then
+        >&2 say_red "error: could not determine latest dev version of Pulumi, try passing --version X.Y.Z to"
+        >&2 say_red "       install an explicit version, or no argument to get the latest release version"
+        exit 1
+    fi
+fi
+
 if [ -z "${VERSION}" ]; then
 
     # Query pulumi.com/latest-version for the most recent release. Because this approach


### PR DESCRIPTION
In addition to specifying the exact version, allow users to specify `--version=dev` to install the latest dev version of the Pulumi CLI. This will make use of the `latest-dev-version` file added in https://github.com/pulumi/docs/pull/10365.

Fixes https://github.com/pulumi/get.pulumi.com/issues/169