### PR TITLE
Add install-root and no-edit-path options to CLI install scripts

### DIFF
--- a/dist/install.ps1
+++ b/dist/install.ps1
@@ -1,5 +1,7 @@
 param(
-    [string]$Version
+    [string]$Version,
+    [string]$InstallRoot=$null,
+    [bool]$NoEditPath=$false
 )
 
 Set-StrictMode -Version Latest
@@ -42,8 +44,12 @@ if ($PSVersionTable.PSVersion.Major -ge 5) {
     [System.IO.Compression.ZipFile]::ExtractToDirectory($tempZip, $tempDir)
 }
 
-# Install into %USERPROFILE%\.pulumi\bin
-$pulumiInstallRoot = (Join-Path $env:UserProfile ".pulumi")
+$pulumiInstallRoot = $InstallRoot
+if (-not $pulumiInstallRoot) {
+    # Install into %USERPROFILE%\.pulumi\bin by default
+    $pulumiInstallRoot = (Join-Path $env:UserProfile ".pulumi")
+}
+
 $binRoot = (Join-Path $pulumiInstallRoot "bin")
 
 Write-Host "Copying Pulumi to $binRoot"
@@ -74,19 +80,21 @@ if (Test-Path (Join-Path $tempDir (Join-Path "pulumi" "bin"))) {
 
 
 # Attempt to add ourselves to the $PATH, but if we can't, don't fail the overall script.
-try {
-    $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree);
-    $val = $envKey.GetValue("PATH", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames);
-    if ($val -notlike "*${binRoot};*") {
-        $envKey.SetValue("PATH", "$binRoot;$val", [Microsoft.Win32.RegistryValueKind]::ExpandString);
-        Write-Host "Added $binRoot to the `$PATH. Changes may not be visible until after a restart."
+if ($NoEditPath -eq $false) {
+    try {
+        $envKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree);
+        $val = $envKey.GetValue("PATH", "", [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames);
+        if ($val -notlike "*${binRoot};*") {
+            $envKey.SetValue("PATH", "$binRoot;$val", [Microsoft.Win32.RegistryValueKind]::ExpandString);
+            Write-Host "Added $binRoot to the `$PATH. Changes may not be visible until after a restart."
+        }
+        $envKey.Close();
+    } catch {
     }
-    $envKey.Close();
-} catch {
-}
 
-if ($env:PATH -notlike "*$binRoot*") {
-    $env:PATH = "$binRoot;$env:PATH"
+    if ($env:PATH -notlike "*$binRoot*") {
+        $env:PATH = "$binRoot;$env:PATH"
+    }
 }
 
 # And cleanup our temp files

--- a/dist/install.ps1
+++ b/dist/install.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$Version,
     [string]$InstallRoot=$null,
-    [bool]$NoEditPath=$false
+    [switch]$NoEditPath,
 )
 
 Set-StrictMode -Version Latest

--- a/dist/install.ps1
+++ b/dist/install.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$Version,
     [string]$InstallRoot=$null,
-    [switch]$NoEditPath,
+    [switch]$NoEditPath
 )
 
 Set-StrictMode -Version Latest

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -191,56 +191,58 @@ fi
 
 # Now that we have installed Pulumi, if it is not already on the path, let's add a line to the
 # user's profile to add the folder to the PATH for future sessions.
-if [ "${NO_EDIT_PATH}" != "true" ]; then
-    if ! command -v pulumi >/dev/null; then
-        # If we can, we'll add a line to the user's .profile adding ${PULUMI_INSTALL_ROOT}/bin to the PATH
-        SHELL_NAME=$(basename "${SHELL}")
-        PROFILE_FILE=""
+if [ "${NO_EDIT_PATH}" != "true" ] && ! command -v pulumi >/dev/null; then
+    # If we can, we'll add a line to the user's .profile adding ${PULUMI_INSTALL_ROOT}/bin to the PATH
+    SHELL_NAME=$(basename "${SHELL}")
+    PROFILE_FILE=""
 
-        case "${SHELL_NAME}" in
-            "bash")
-                # Terminal.app on macOS prefers .bash_profile to .bashrc, so we prefer that
-                # file when trying to put our export into a profile. On *NIX, .bashrc is
-                # preferred as it is sourced for new interactive shells.
-                if [ "$(uname)" != "Darwin" ]; then
-                    if [ -e "${HOME}/.bashrc" ]; then
-                        PROFILE_FILE="${HOME}/.bashrc"
-                    elif [ -e "${HOME}/.bash_profile" ]; then
-                        PROFILE_FILE="${HOME}/.bash_profile"
-                    fi
-                else
-                    if [ -e "${HOME}/.bash_profile" ]; then
-                        PROFILE_FILE="${HOME}/.bash_profile"
-                    elif [ -e "${HOME}/.bashrc" ]; then
-                        PROFILE_FILE="${HOME}/.bashrc"
-                    fi
+    case "${SHELL_NAME}" in
+        "bash")
+            # Terminal.app on macOS prefers .bash_profile to .bashrc, so we prefer that
+            # file when trying to put our export into a profile. On *NIX, .bashrc is
+            # preferred as it is sourced for new interactive shells.
+            if [ "$(uname)" != "Darwin" ]; then
+                if [ -e "${HOME}/.bashrc" ]; then
+                    PROFILE_FILE="${HOME}/.bashrc"
+                elif [ -e "${HOME}/.bash_profile" ]; then
+                    PROFILE_FILE="${HOME}/.bash_profile"
                 fi
-                ;;
-            "zsh")
-                if [ -e "${ZDOTDIR:-$HOME}/.zshrc" ]; then
-                    PROFILE_FILE="${ZDOTDIR:-$HOME}/.zshrc"
+            else
+                if [ -e "${HOME}/.bash_profile" ]; then
+                    PROFILE_FILE="${HOME}/.bash_profile"
+                elif [ -e "${HOME}/.bashrc" ]; then
+                    PROFILE_FILE="${HOME}/.bashrc"
                 fi
-                ;;
-        esac
-
-        if [ -n "${PROFILE_FILE}" ]; then
-            LINE_TO_ADD="export PATH=\$PATH:${PULUMI_INSTALL_ROOT}/bin"
-            if ! grep -q "# add Pulumi to the PATH" "${PROFILE_FILE}"; then
-                say_white "+ Adding ${PULUMI_INSTALL_ROOT}/bin to \$PATH in ${PROFILE_FILE}"
-                printf "\\n# add Pulumi to the PATH\\n%s\\n" "${LINE_TO_ADD}" >> "${PROFILE_FILE}"
             fi
+            ;;
+        "zsh")
+            if [ -e "${ZDOTDIR:-$HOME}/.zshrc" ]; then
+                PROFILE_FILE="${ZDOTDIR:-$HOME}/.zshrc"
+            fi
+            ;;
+    esac
 
-            EXTRA_INSTALL_STEP="+ Please restart your shell or add ${PULUMI_INSTALL_ROOT}/bin to your \$PATH"
-        else
-            EXTRA_INSTALL_STEP="+ Please add ${PULUMI_INSTALL_ROOT}/bin to your \$PATH"
+    if [ -n "${PROFILE_FILE}" ]; then
+        LINE_TO_ADD="export PATH=\$PATH:${PULUMI_INSTALL_ROOT}/bin"
+        if ! grep -q "# add Pulumi to the PATH" "${PROFILE_FILE}"; then
+            say_white "+ Adding ${PULUMI_INSTALL_ROOT}/bin to \$PATH in ${PROFILE_FILE}"
+            printf "\\n# add Pulumi to the PATH\\n%s\\n" "${LINE_TO_ADD}" >> "${PROFILE_FILE}"
         fi
-    elif [ "$(command -v pulumi)" != "${PULUMI_INSTALL_ROOT}/bin/pulumi" ]; then
-        say_yellow
-        say_yellow "warning: Pulumi has been installed to ${PULUMI_INSTALL_ROOT}/bin, but it looks like there's a different copy"
-        say_yellow "         on your \$PATH at $(dirname "$(command -v pulumi)"). You'll need to explicitly invoke the"
-        say_yellow "         version you just installed or modify your \$PATH to prefer this location."
+
+        EXTRA_INSTALL_STEP="+ Please restart your shell or add ${PULUMI_INSTALL_ROOT}/bin to your \$PATH"
+    else
+        EXTRA_INSTALL_STEP="+ Please add ${PULUMI_INSTALL_ROOT}/bin to your \$PATH"
     fi
 fi
+
+# Warn if the pulumi command is available, but it is in a different location from the current install root.
+if [ "$(command -v pulumi)" != "" ] && [ "$(command -v pulumi)" != "${PULUMI_INSTALL_ROOT}/bin/pulumi" ]; then
+    say_yellow
+    say_yellow "warning: Pulumi has been installed to ${PULUMI_INSTALL_ROOT}/bin, but it looks like there's a different copy"
+    say_yellow "         on your \$PATH at $(dirname "$(command -v pulumi)"). You'll need to explicitly invoke the"
+    say_yellow "         version you just installed or modify your \$PATH to prefer this location."
+fi
+
 say_blue
 say_blue "=== Pulumi is now installed! 🍹 ==="
 if [ "$EXTRA_INSTALL_STEP" != "" ]; then

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -60,6 +60,8 @@ at_exit()
 trap at_exit EXIT
 
 VERSION=""
+INSTALL_ROOT=""
+NO_EDIT_PATH=""
 SILENT=""
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -70,6 +72,12 @@ while [ $# -gt 0 ]; do
             ;;
         --silent)
             SILENT="--silent"
+            ;;
+        --install-root)
+            INSTALL_ROOT=$2
+            ;;
+        --no-edit-path)
+            NO_EDIT_PATH="true"
             ;;
      esac
      shift
@@ -117,11 +125,18 @@ esac
 TARBALL_URL="https://github.com/pulumi/pulumi/releases/download/v${VERSION}/"
 TARBALL_URL_FALLBACK="https://get.pulumi.com/releases/sdk/"
 TARBALL_PATH=pulumi-v${VERSION}-${OS}-${ARCH}.tar.gz
+PULUMI_INSTALL_ROOT=${INSTALL_ROOT}
 
-if ! command -v pulumi >/dev/null; then
+if [ "$PULUMI_INSTALL_ROOT" = "" ]; then
+    # Default to ~/.pulumi
+    PULUMI_INSTALL_ROOT="${HOME}/.pulumi"
+fi
+PULUMI_CLI="${PULUMI_INSTALL_ROOT}/bin/pulumi"
+
+if [ ! -e "${PULUMI_CLI}" ]; then
     say_blue "=== Installing Pulumi v${VERSION} ==="
 else
-    say_blue "=== Upgrading Pulumi $(pulumi version) to v${VERSION} ==="
+    say_blue "=== Upgrading Pulumi $(${PULUMI_CLI} version) to v${VERSION} ==="
 fi
 
 TARBALL_DEST=$(mktemp -t pulumi.tar.gz.XXXXXXXXXX)
@@ -142,14 +157,14 @@ download_tarball() {
 }
 
 if download_tarball; then
-    say_white "+ Extracting to $HOME/.pulumi/bin"
+    say_white "+ Extracting to ${PULUMI_INSTALL_ROOT}/bin"
 
-    # If `~/.pulumi/bin` exists, remove previous files with a pulumi prefix
-    if [ -e "${HOME}/.pulumi/bin/pulumi" ]; then
-        rm "${HOME}/.pulumi/bin"/pulumi*
+    # If \`~/.pulumi/bin\` exists, remove previous files with a pulumi prefix
+    if [ -e "${PULUMI_INSTALL_ROOT}/bin/pulumi" ]; then
+        rm "${PULUMI_INSTALL_ROOT}/bin"/pulumi*
     fi
 
-    mkdir -p "${HOME}/.pulumi"
+    mkdir -p "${PULUMI_INSTALL_ROOT}"
 
     # Yarn's shell installer does a similar dance of extracting to a temp
     # folder and copying to not depend on additional tar flags
@@ -160,9 +175,9 @@ if download_tarball; then
     # format if we detect it. Newer tarballs just have all the binaries in
     # the top level Pulumi folder.
     if [ -d "${EXTRACT_DIR}/pulumi/bin" ]; then
-        mv "${EXTRACT_DIR}/pulumi/bin" "${HOME}/.pulumi/"
+        mv "${EXTRACT_DIR}/pulumi/bin" "${PULUMI_INSTALL_ROOT}/"
     else
-        cp -r "${EXTRACT_DIR}/pulumi/." "${HOME}/.pulumi/bin/"
+        cp -r "${EXTRACT_DIR}/pulumi/." "${PULUMI_INSTALL_ROOT}/bin/"
     fi
 
     rm -f "${TARBALL_DEST}"
@@ -176,55 +191,56 @@ fi
 
 # Now that we have installed Pulumi, if it is not already on the path, let's add a line to the
 # user's profile to add the folder to the PATH for future sessions.
-if ! command -v pulumi >/dev/null; then
-    # If we can, we'll add a line to the user's .profile adding $HOME/.pulumi/bin to the PATH
-    SHELL_NAME=$(basename "${SHELL}")
-    PROFILE_FILE=""
+if [ "${NO_EDIT_PATH}" != "true" ]; then
+    if ! command -v pulumi >/dev/null; then
+        # If we can, we'll add a line to the user's .profile adding ${PULUMI_INSTALL_ROOT}/bin to the PATH
+        SHELL_NAME=$(basename "${SHELL}")
+        PROFILE_FILE=""
 
-    case "${SHELL_NAME}" in
-        "bash")
-            # Terminal.app on macOS prefers .bash_profile to .bashrc, so we prefer that
-            # file when trying to put our export into a profile. On *NIX, .bashrc is
-            # preferred as it is sourced for new interactive shells.
-            if [ "$(uname)" != "Darwin" ]; then
-                if [ -e "${HOME}/.bashrc" ]; then
-                    PROFILE_FILE="${HOME}/.bashrc"
-                elif [ -e "${HOME}/.bash_profile" ]; then
-                    PROFILE_FILE="${HOME}/.bash_profile"
+        case "${SHELL_NAME}" in
+            "bash")
+                # Terminal.app on macOS prefers .bash_profile to .bashrc, so we prefer that
+                # file when trying to put our export into a profile. On *NIX, .bashrc is
+                # preferred as it is sourced for new interactive shells.
+                if [ "$(uname)" != "Darwin" ]; then
+                    if [ -e "${HOME}/.bashrc" ]; then
+                        PROFILE_FILE="${HOME}/.bashrc"
+                    elif [ -e "${HOME}/.bash_profile" ]; then
+                        PROFILE_FILE="${HOME}/.bash_profile"
+                    fi
+                else
+                    if [ -e "${HOME}/.bash_profile" ]; then
+                        PROFILE_FILE="${HOME}/.bash_profile"
+                    elif [ -e "${HOME}/.bashrc" ]; then
+                        PROFILE_FILE="${HOME}/.bashrc"
+                    fi
                 fi
-            else
-                if [ -e "${HOME}/.bash_profile" ]; then
-                    PROFILE_FILE="${HOME}/.bash_profile"
-                elif [ -e "${HOME}/.bashrc" ]; then
-                    PROFILE_FILE="${HOME}/.bashrc"
+                ;;
+            "zsh")
+                if [ -e "${ZDOTDIR:-$HOME}/.zshrc" ]; then
+                    PROFILE_FILE="${ZDOTDIR:-$HOME}/.zshrc"
                 fi
-            fi
-            ;;
-        "zsh")
-            if [ -e "${ZDOTDIR:-$HOME}/.zshrc" ]; then
-                PROFILE_FILE="${ZDOTDIR:-$HOME}/.zshrc"
-            fi
-            ;;
-    esac
+                ;;
+        esac
 
-    if [ -n "${PROFILE_FILE}" ]; then
-        LINE_TO_ADD="export PATH=\$PATH:\$HOME/.pulumi/bin"
-        if ! grep -q "# add Pulumi to the PATH" "${PROFILE_FILE}"; then
-            say_white "+ Adding \$HOME/.pulumi/bin to \$PATH in ${PROFILE_FILE}"
-            printf "\\n# add Pulumi to the PATH\\n%s\\n" "${LINE_TO_ADD}" >> "${PROFILE_FILE}"
+        if [ -n "${PROFILE_FILE}" ]; then
+            LINE_TO_ADD="export PATH=\$PATH:\${PULUMI_INSTALL_ROOT}/bin"
+            if ! grep -q "# add Pulumi to the PATH" "${PROFILE_FILE}"; then
+                say_white "+ Adding \${PULUMI_INSTALL_ROOT}/bin to \$PATH in ${PROFILE_FILE}"
+                printf "\\n# add Pulumi to the PATH\\n%s\\n" "${LINE_TO_ADD}" >> "${PROFILE_FILE}"
+            fi
+
+            EXTRA_INSTALL_STEP="+ Please restart your shell or add ${PULUMI_INSTALL_ROOT}/bin to your \$PATH"
+        else
+            EXTRA_INSTALL_STEP="+ Please add ${PULUMI_INSTALL_ROOT}/bin to your \$PATH"
         fi
-
-        EXTRA_INSTALL_STEP="+ Please restart your shell or add $HOME/.pulumi/bin to your \$PATH"
-    else
-        EXTRA_INSTALL_STEP="+ Please add $HOME/.pulumi/bin to your \$PATH"
+    elif [ "$(command -v pulumi)" != "${PULUMI_INSTALL_ROOT}/bin/pulumi" ]; then
+        say_yellow
+        say_yellow "warning: Pulumi has been installed to ${PULUMI_INSTALL_ROOT}/bin, but it looks like there's a different copy"
+        say_yellow "         on your \$PATH at $(dirname "$(command -v pulumi)"). You'll need to explicitly invoke the"
+        say_yellow "         version you just installed or modify your \$PATH to prefer this location."
     fi
-elif [ "$(command -v pulumi)" != "$HOME/.pulumi/bin/pulumi" ]; then
-    say_yellow
-    say_yellow "warning: Pulumi has been installed to $HOME/.pulumi/bin, but it looks like there's a different copy"
-    say_yellow "         on your \$PATH at $(dirname "$(command -v pulumi)"). You'll need to explicitly invoke the"
-    say_yellow "         version you just installed or modify your \$PATH to prefer this location."
 fi
-
 say_blue
 say_blue "=== Pulumi is now installed! 🍹 ==="
 if [ "$EXTRA_INSTALL_STEP" != "" ]; then

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -159,7 +159,7 @@ download_tarball() {
 if download_tarball; then
     say_white "+ Extracting to ${PULUMI_INSTALL_ROOT}/bin"
 
-    # If \`~/.pulumi/bin\` exists, remove previous files with a pulumi prefix
+    # If `~/.pulumi/bin` exists, remove previous files with a pulumi prefix
     if [ -e "${PULUMI_INSTALL_ROOT}/bin/pulumi" ]; then
         rm "${PULUMI_INSTALL_ROOT}/bin"/pulumi*
     fi
@@ -224,9 +224,9 @@ if [ "${NO_EDIT_PATH}" != "true" ]; then
         esac
 
         if [ -n "${PROFILE_FILE}" ]; then
-            LINE_TO_ADD="export PATH=\$PATH:\${PULUMI_INSTALL_ROOT}/bin"
+            LINE_TO_ADD="export PATH=\$PATH:${PULUMI_INSTALL_ROOT}/bin"
             if ! grep -q "# add Pulumi to the PATH" "${PROFILE_FILE}"; then
-                say_white "+ Adding \${PULUMI_INSTALL_ROOT}/bin to \$PATH in ${PROFILE_FILE}"
+                say_white "+ Adding ${PULUMI_INSTALL_ROOT}/bin to \$PATH in ${PROFILE_FILE}"
                 printf "\\n# add Pulumi to the PATH\\n%s\\n" "${LINE_TO_ADD}" >> "${PROFILE_FILE}"
             fi
 

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -133,7 +133,10 @@ if [ "$PULUMI_INSTALL_ROOT" = "" ]; then
 fi
 PULUMI_CLI="${PULUMI_INSTALL_ROOT}/bin/pulumi"
 
-if [ ! -e "${PULUMI_CLI}" ]; then
+if [ -d "${PULUMI_CLI}" ]; then
+    say_red "error: ${PULUMI_CLI} already exists and is a directory, refusing to proceed."
+    exit 1
+elif [ ! -f "${PULUMI_CLI}" ]; then
     say_blue "=== Installing Pulumi v${VERSION} ==="
 else
     say_blue "=== Upgrading Pulumi $(${PULUMI_CLI} version) to v${VERSION} ==="


### PR DESCRIPTION
Adds two new options:

 * --install-root $DIR: if present, installs into $DIR instead of
   $HOME/.pulumi
 * --no-edit-path: if present, does not attempt to add the
   $PULUMI_INSTALL_ROOT/bin to $PATH

[Ignore whitespace for easier reviewing
](https://github.com/pulumi/get.pulumi.com/pull/171/files?diff=split&w=1)

Code from [pgavlin/auto-install](https://github.com/pulumi/pulumi/compare/master...pgavlin/auto-install) with some slight changes for the `--no-edit-path`/`NoEditPath` option and fixes for the PowerShell params syntax.