### PR TITLE
Backport production changes to master

### DIFF
--- a/dist/esc/install.ps1
+++ b/dist/esc/install.ps1
@@ -64,7 +64,7 @@ if (-not (Test-Path -Path $binRoot -PathType Container)) {
 }
 
 # Copy the esc binary to %USERPROFILE%\.pulumi\bin
-Move-Item -Path (Join-Path $tempDir "esc") -Destination $escPath -Force
+Move-Item -Path (Join-Path $tempDir "esc\bin\esc.exe") -Destination $binRoot -Force
 
 
 # Attempt to add ourselves to the $PATH, but if we can't, don't fail the overall script.

--- a/dist/esc/install.ps1
+++ b/dist/esc/install.ps1
@@ -10,19 +10,12 @@ $ProgressPreference="SilentlyContinue"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 if ($Version -eq $null -or $Version -eq "") {
-    # TODO: removed hardcoded version
-    $latestVersion="0.5.1"
-
-    # TODO: add latest-version support for pulumi/esc
-    # Query pulumi.com/latest-version for the most recent release. Because this approach
+    # Query pulumi.com/esc/latest-version for the most recent release. Because this approach
     # is now used by third parties as well (e.g., GitHub Actions virtual environments),
     # changes to this API should be made with care to avoid breaking any services that
-    # rely on it (and ideally be accompanied by PRs to update them accordingly). Known
-    # consumers of this API include:
-    #
-    # * https://github.com/actions/virtual-environments
-    #
-#    $latestVersion = (Invoke-WebRequest -UseBasicParsing https://www.pulumi.com/latest-version).Content.Trim()
+    # rely on it (and ideally be accompanied by PRs to update them accordingly).
+
+    $latestVersion = (Invoke-WebRequest -UseBasicParsing https://www.pulumi.com/esc/latest-version).Content.Trim()
     $Version = $latestVersion
 }
 

--- a/dist/esc/install.sh
+++ b/dist/esc/install.sh
@@ -153,7 +153,7 @@ if download_tarball; then
         rm -rf "${HOME}/.pulumi/bin/esc"
     fi
 
-    mkdir -p "${HOME}/.pulumi"
+    mkdir -p "${HOME}/.pulumi/bin"
 
     # Yarn's shell installer does a similar dance of extracting to a temp
     # folder and copying to not depend on additional tar flags

--- a/dist/esc/install.sh
+++ b/dist/esc/install.sh
@@ -151,7 +151,7 @@ if download_tarball; then
     EXTRACT_DIR=$(mktemp -dt esc.XXXXXXXXXX)
     tar zxf "${TARBALL_DEST}" -C "${EXTRACT_DIR}"
 
-    cp -r "${EXTRACT_DIR}/esc" "${HOME}/.pulumi/bin/"
+    cp "${EXTRACT_DIR}/esc/esc" "${HOME}/.pulumi/bin/"
 
     rm -f "${TARBALL_DEST}"
     rm -rf "${EXTRACT_DIR}"

--- a/dist/esc/install.sh
+++ b/dist/esc/install.sh
@@ -76,25 +76,16 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "${VERSION}" ]; then
-    # TODO: remove hardcoded version
-    VERSION=0.5.1
-
-    # TODO: add latest-version support for pulumi/esc
-
-    # Query pulumi.com/latest-version for the most recent release. Because this approach
+    # Query pulumi.com/esc/latest-version for the most recent release. Because this approach
     # is now used by third parties as well (e.g., GitHub Actions virtual environments),
     # changes to this API should be made with care to avoid breaking any services that
-    # rely on it (and ideally be accompanied by PRs to update them accordingly). Known
-    # consumers of this API include:
-    #
-    # * https://github.com/actions/virtual-environments
-    #
+    # rely on it (and ideally be accompanied by PRs to update them accordingly).
 
-#    if ! VERSION=$(curl --retry 3 --fail --silent -L "https://www.pulumi.com/latest-version"); then
-#        >&2 say_red "error: could not determine latest version of Pulumi ESC, try passing --version X.Y.Z to"
-#        >&2 say_red "       install an explicit version"
-#        exit 1
-#    fi
+    if ! VERSION=$(curl --retry 3 --fail --silent -L "https://www.pulumi.com/esc/latest-version"); then
+        >&2 say_red "error: could not determine latest version of Pulumi ESC, try passing --version X.Y.Z to"
+        >&2 say_red "       install an explicit version"
+        exit 1
+    fi
 fi
 
 OS=""


### PR DESCRIPTION
Production has a couple changes that are not master. This PR backports these so we can cleanly merge master into production.

- Create .bin if it doesn't exist
- Fix windows install directory
- Use pulumi.com/esc/latest-version
- Fix ESC install.sh
