### PR TITLE
Enable downloading Pulumi from pull releases

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -50,7 +50,8 @@ at_exit()
     # shellcheck disable=SC2181
     # https://github.com/koalaman/shellcheck/wiki/SC2181
     # Disable because we don't actually know the command we're running
-    if [ "$?" -ne 0 ]; then
+    STATUS="$?"
+    if [ "$STATUS" -ne 0 ] && [ "$STATUS" -ne 33 ]; then
         >&2 say_red
         >&2 say_red "We're sorry, but it looks like something might have gone wrong during installation."
         >&2 say_red "If you need help, please join us on https://slack.pulumi.com/"
@@ -268,7 +269,7 @@ download_tarball() {
         if ! curl --retry 2 --fail ${SILENT} -L -o "${TARBALL_DEST}" "${TARBALL_URL_FALLBACK}${TARBALL_PATH}"; then
             return 1
         fi
-	    return 0
+        return 0
     fi
     # Try to download from github first, then fallback to get.pulumi.com
     say_white "+ Downloading ${TARBALL_URL}${TARBALL_PATH}..."
@@ -313,7 +314,7 @@ if download_tarball; then
 else
     if [ "$PR_NUMBER" != "" ]; then
         >&2 say_red "error: failed to download PR ${PR_NUMBER}"
-        exit 0 # skip ordinary error message
+        exit 33 # skip ordinary error message
     else
         >&2 say_red "error: failed to download ${TARBALL_URL}"
         >&2 say_red "       check your internet and try again; if the problem persists, file an"


### PR DESCRIPTION
After this change, the install script will accept versions like `pr#16961`, and will download and install the Pulumi binary from the corresponding pull release artifacts.

As these artifacts are stored in GitHub CI and only accessible to authenticated users, a GITHUB_TOKEN environment variable must be set to a valid GitHub token with read access to the pulumi/pulumi repository. If this token is not set, the GitHub CLI is used to obtain a token, and if that fails then an error is presented.

```sh
./dist/install.sh --version pr#16961
=== Installing Pulumi vpr#16961 ===
+ Downloading https://api.github.com/repos/pulumi/pulumi/actions/artifacts/1808372004/zip to /tmp/pulumi.tar.gz.zip.wfe772a0CV...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  179M  100  179M    0     0  14.6M      0  0:00:12  0:00:12 --:--:-- 13.5M
+ Extracting /tmp/pulumi.tar.gz.zip.wfe772a0CV to /tmp/pulumi.zip.oDmKx4Evb5...
+ Extracting to /home/friel/.pulumi/bin

=== Pulumi is now installed! 🍹 ===
+ Get started with Pulumi: https://www.pulumi.com/docs/quickstart
```

After this is released, developers can use this feature via:

```sh
curl -fsSL https://get.pulumi.com | sh -s -- --version pr#<NUMBER>
```