### PR TITLE
Add new public ECR repos for nodejs and dotnet to IAM role

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -156,8 +156,10 @@ const productionImageRepositories = [
     "esc",
     "pulumi",
     "pulumi-dotnet",
+    "pulumi-dotnet-*", // We have individual repos for versions dotnet 6.0 & 8.0
     "pulumi-go",
     "pulumi-nodejs",
+    "pulumi-nodejs-*", // We have individual repos for versions nodejs 18, 20 & 22
     "pulumi-python",
     "pulumi-python-*", // We have individual repos for versions python 3.9-3.12
     "pulumi-kubernetes-operator",


### PR DESCRIPTION
Add the repos for the version-suffixed images for dotnet and nodejs to the IAM role permissions.

The following ECR repos need to be created manually first:

- pulumi-dotnet-6.0
- pulumi-dotnet-8.0
- pulumi-nodejs-18
- pulumi-nodejs-20
- pulumi-nodejs-22

See also https://github.com/pulumi/get.pulumi.com/pull/179 & https://pulumi.slack.com/archives/C6Y560ADV/p1722963019466569