### PR TITLE
Enforce TLS on get.pulumi.com buckets

### DIFF
--- a/infrastructure/Pulumi.production.yaml
+++ b/infrastructure/Pulumi.production.yaml
@@ -2,4 +2,3 @@ config:
   aws:region: us-west-2
   get-pulumi-com:certificateArn: arn:aws:acm:us-east-1:058607598222:certificate/a3f72a2b-e715-4639-b126-1e4efc0b634b
   get-pulumi-com:domain: pulumi.com
-  get-pulumi-com:dataWorkflowsBucketReaderRoleArn: arn:aws:iam::777369438443:role/snowpipe-prodbuckets-to-snowflake-role

--- a/infrastructure/Pulumi.production.yaml
+++ b/infrastructure/Pulumi.production.yaml
@@ -2,3 +2,4 @@ config:
   aws:region: us-west-2
   get-pulumi-com:certificateArn: arn:aws:acm:us-east-1:058607598222:certificate/a3f72a2b-e715-4639-b126-1e4efc0b634b
   get-pulumi-com:domain: pulumi.com
+  get-pulumi-com:dataWorkflowsBucketReaderRoleArn: arn:aws:iam::777369438443:role/snowpipe-prodbuckets-to-snowflake-role


### PR DESCRIPTION
Part of pentesting remediation: https://github.com/pulumi/pulumi-service/issues/25783

Confirmed with Pablo that we're good to remove the ACL and not include the data warehouse bucket policies since they're not importing the logs bucket anymore because we're using cloudflare now