### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-get.pulumi.com
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Staging
 on:
   push:
@@ -19,14 +26,20 @@ jobs:
       run:
         working-directory: infrastructure
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
+        aws-access-key-id: ${{ steps.esc-secrets.outputs.CI_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ steps.esc-secrets.outputs.CI_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
+        role-to-assume: ${{ steps.esc-secrets.outputs.AWS_ROLE_TO_ASSUME_STAGING }}
+        role-external-id: "pulumi/get-pulumi-com/staging"
         role-duration-seconds: 3600
         role-session-name: get.pulumi.com-${{ github.run_id }}
     - run: yarn install
@@ -37,4 +50,4 @@ jobs:
         stack-name: "pulumi/get-pulumi-com/staging"
         work-dir: infrastructure
       env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,11 +35,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ steps.esc-secrets.outputs.CI_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ steps.esc-secrets.outputs.CI_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
         role-to-assume: ${{ steps.esc-secrets.outputs.AWS_ROLE_TO_ASSUME_STAGING }}
-        role-external-id: "pulumi/get-pulumi-com/staging"
         role-duration-seconds: 3600
         role-session-name: get.pulumi.com-${{ github.run_id }}
     - run: yarn install

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -32,11 +32,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ steps.esc-secrets.outputs.CI_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ steps.esc-secrets.outputs.CI_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
         role-to-assume: ${{ steps.esc-secrets.outputs.AWS_ROLE_TO_ASSUME_PRODUCTION }}
-        role-external-id: "pulumi/get-pulumi-com/production"
         role-duration-seconds: 3600
         role-session-name: get.pulumi.com-${{ github.run_id }}
     - run: yarn install

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-get.pulumi.com
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Production
 on:
   push:
@@ -18,12 +25,18 @@ jobs:
       run:
         working-directory: infrastructure
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - uses: actions/checkout@v4
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
+        aws-access-key-id: ${{ steps.esc-secrets.outputs.CI_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ steps.esc-secrets.outputs.CI_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME_PRODUCTION }}
+        role-to-assume: ${{ steps.esc-secrets.outputs.AWS_ROLE_TO_ASSUME_PRODUCTION }}
+        role-external-id: "pulumi/get-pulumi-com/production"
         role-duration-seconds: 3600
         role-session-name: get.pulumi.com-${{ github.run_id }}
     - run: yarn install
@@ -34,4 +47,4 @@ jobs:
         stack-name: "pulumi/get-pulumi-com/production"
         work-dir: infrastructure
       env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-get.pulumi.com
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: pull-request
 on: pull_request
 
@@ -14,15 +21,20 @@ jobs:
       id-token: write
       contents: read
     env:
-      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME_STAGING }}
+      ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: AWS_ROLE_TO_ASSUME=AWS_ROLE_TO_ASSUME_STAGING
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - if: github.base_ref == 'production'
       run: |
-          echo "AWS_ROLE_TO_ASSUME=${{ secrets.AWS_ROLE_TO_ASSUME_PRODUCTION }}" >> $GITHUB_ENV
+          echo "AWS_ROLE_TO_ASSUME=${{ steps.esc-secrets.outputs.AWS_ROLE_TO_ASSUME_PRODUCTION }}" >> $GITHUB_ENV
     - uses: actions/checkout@v4
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
+        aws-access-key-id: ${{ steps.esc-secrets.outputs.CI_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ steps.esc-secrets.outputs.CI_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
         role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 3600
@@ -36,7 +48,7 @@ jobs:
         work-dir: infrastructure
         stack-name: "pulumi/get-pulumi-com/production"
       env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
     - if: github.base_ref == 'master'
       uses: pulumi/actions@8e5e406f4007fca908480587cb9893c07090f58d # v7
       with:
@@ -44,4 +56,4 @@ jobs:
         work-dir: infrastructure
         stack-name: "pulumi/get-pulumi-com/staging"
       env:
-        PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,8 +33,6 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ steps.esc-secrets.outputs.CI_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ steps.esc-secrets.outputs.CI_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
         role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 3600


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
