### PR TITLE
Add new ECR repository for Node.js 24

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -187,6 +187,7 @@ const repositoryNames: RepoInfo[] = [
     { name: "pulumi-nodejs-20", about: "Pulumi CLI container for NodeJS 20"},
     { name: "pulumi-nodejs-22", about: "Pulumi CLI container for NodeJS 22"},
     { name: "pulumi-nodejs-23", about: "Pulumi CLI container for NodeJS 23"},
+    { name: "pulumi-nodejs-24", about: "Pulumi CLI container for NodeJS 24"},
     { name: "pulumi-python", about: "Pulumi CLI container for Python"},
     { name: "pulumi-python-3.9", about: "Pulumi CLI container for Python 3.9"},
     { name: "pulumi-python-3.10", about: "Pulumi CLI container for Python 3.10"},


### PR DESCRIPTION
Node.js 24 is out, create a new ECR repo for the new image.