### PR TITLE
Add workflow to export repo secrets

### DIFF
--- a/.github/workflows/export-repo-secrets.yml
+++ b/.github/workflows/export-repo-secrets.yml
@@ -1,0 +1,25 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+name: Export secrets to ESC
+on: [ workflow_dispatch ]
+jobs:
+  export-to-esc:
+    runs-on: ubuntu-latest
+    name: export GitHub secrets to ESC
+    steps:
+      - name: Generate a GitHub token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: 1256780 # Export Secrets GitHub App
+          private-key: ${{ secrets.EXPORT_SECRETS_PRIVATE_KEY }}
+      - name: Export secrets to ESC
+        uses: pulumi/esc-export-secrets-action@v1
+        with:
+          organization: pulumi
+          org-environment: imports/github-secrets
+          exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
+          github-token: ${{ steps.generate-token.outputs.token }}
+          oidc-auth: true
+          oidc-requested-token-type: urn:pulumi:token-type:access_token:organization
+        env:
+          GITHUB_SECRETS: ${{ toJSON(secrets) }}


### PR DESCRIPTION
This repository has repository-specific secrets that need to be migrated to ESC. These changes add a GitHub Actions workflow to perform this migration.

The workflow is configured to be run manually. It is only expected that the worflow will be run once. The workflow uses https://github.com/pulumi/esc-export-secrets-action to create a new ESC environment to hold the repository's secrets. This environment also imports the environment that holds the organization's secrets.
