### PR TITLE
fix: correct argument parsing in install script

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -70,15 +70,22 @@ while [ $# -gt 0 ]; do
             if [ "$2" != "latest" ]; then
                 VERSION=$2
             fi
+            shift
             ;;
         --silent)
             SILENT="--silent"
             ;;
         --install-root)
             INSTALL_ROOT=$2
+            shift
             ;;
         --no-edit-path)
             NO_EDIT_PATH="true"
+            ;;
+        *)
+            >&2 say_red "error: unknown option '$1'"
+            >&2 say_red "usage: install.sh [--version <version>] [--install-root <path>] [--no-edit-path] [--silent]"
+            exit 1
             ;;
      esac
      shift


### PR DESCRIPTION
## Summary

Fixes pulumi/pulumi#22508

The argument parser in `dist/install.sh` has two bugs:

### 1. Missing `shift` for options with values

`--version` and `--install-root` consume `$2` as their value but don't `shift` past it. The value is re-processed as the next option on the next iteration.

```sh
# Before: --version 3.99.0 → VERSION=3.99.0, then '3.99.0' is processed as an option
--version)
    VERSION=$2  # no shift!
    ;;
```

This works by accident because unrecognized arguments fall through silently.

### 2. No default handler for unknown options

Typos like `--versoin` or `--silient` are silently ignored.

## Fix

- Add `shift` after consuming `$2` in `--version` and `--install-root` branches
- Add a default `*)` handler that prints an error and exits