### PR TITLE
Migrate BucketAclV2 to BucketAcl

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -269,7 +269,7 @@ const logsBucketOwnershipControl = new aws.s3.BucketOwnershipControls(
 // Constant Canonical ID for cloudfront, documented here:
 // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html
 const cloudFrontCanonicalID = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0";
-const logsBucketACL = new aws.s3.BucketAclV2(
+const logsBucketACL = new aws.s3.BucketAcl(
     `${fullDomain}-logs-acl`,
     {
         bucket: logsBucket.id,
@@ -311,6 +311,8 @@ const logsBucketACL = new aws.s3.BucketAclV2(
     },
     {
         dependsOn: logsBucketOwnershipControl,
+        // BucketAclV2 was deprecated in favor of BucketAcl in aws@7. Alias keeps the existing state row.
+        aliases: [{ type: "aws:s3/bucketAclV2:BucketAclV2" }],
     },
 );
 


### PR DESCRIPTION
The S3 ACL deployment has been failing on every Deploy Staging run since #210 bumped `@pulumi/aws` from `^5.0.0` to `^7.0.0`:

```
api error MissingSecurityHeader: Your request was missing a required header: provider=aws@7.28.0
```

`aws.s3.BucketAclV2` was deprecated in aws@7 in favor of `aws.s3.BucketAcl` (the deprecation warning is emitted by every run). The deprecated resource also issues a `PutBucketAcl` request that AWS now rejects without the required security headers, so the workflow has been blocked on this resource for ~6 weeks.

These changes swap the type and add an alias so the existing state row attaches to the new resource. The two resources share the same input type (`BucketAclArgs == BucketAclV2Args`), so this is a mechanical rename.

Fixes #207.