### PR TITLE
Bump @pulumi/aws to ^7.29.0

### DIFF
--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -6,7 +6,7 @@
         "typescript": "^3.5.3"
     },
     "dependencies": {
-        "@pulumi/aws": "^7.0.0",
+        "@pulumi/aws": "^7.29.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/std": "^2.0.0",
         "mime": "^2.4.4"

--- a/infrastructure/yarn.lock
+++ b/infrastructure/yarn.lock
@@ -431,10 +431,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
   integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
-"@pulumi/aws@^7.0.0":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-7.28.0.tgz#179af75fd55098d8f899636803e5fefbf45e8be7"
-  integrity sha512-5AeRmGA5j1pWuMmmOohLJs4U5O3JtJuv1O5kRkOnDFLAz+OJM9MgE2788325E6yJpcNB1ahuv8cr9G+1exz70g==
+"@pulumi/aws@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-7.29.0.tgz#741112ca7cdd0739d660babeefc68d2fc369256a"
+  integrity sha512-gft+uyW9KGhw9OM4Vy5xxgIlN+6Arw3sPDRMg7Ssgj2Aiiu6VagHi2/SWmawwP327Jv7o8QlrNFpP1aq8/f/VA==
   dependencies:
     "@pulumi/pulumi" "^3.142.0"
     mime "^2.0.0"


### PR DESCRIPTION
Attempt to fix #207 by picking up upstream fixes in the AWS provider. v7.29.0 bumps the underlying terraform-provider-aws to 6.44.0.

The Deploy Staging workflow only runs on push to \`master\`, so this can't be validated end-to-end via PR checks. If staging still fails after merge, the next step is a more invasive refactor — either a canned \`log-delivery-write\` ACL (loses the explicit canonical-user grants) or migrating CloudFront from standard logging to standard logging v2 (uses bucket policy, no ACL needed).