### PR TITLE
Make Route53 record management optional

### DIFF
--- a/infrastructure/Pulumi.production.yaml
+++ b/infrastructure/Pulumi.production.yaml
@@ -2,3 +2,6 @@ config:
   aws:region: us-west-2
   get-pulumi-com:certificateArn: arn:aws:acm:us-east-1:058607598222:certificate/a3f72a2b-e715-4639-b126-1e4efc0b634b
   get-pulumi-com:domain: pulumi.com
+  # The production get.pulumi.com record lives behind Cloudflare and is managed
+  # out-of-band, so this stack does not manage it.
+  get-pulumi-com:manageRoute53Record: "false"

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -16,6 +16,9 @@ const subDomain = "get";
 const domain = cfg.require("domain");
 const fullDomain = `${subDomain}.${domain}`;
 const certificateArn = cfg.require("certificateArn");
+// Defaults to true. Production sets this to false because the get.pulumi.com
+// record lives behind Cloudflare and is managed out-of-band.
+const manageRoute53Record = cfg.getBoolean("manageRoute53Record") ?? true;
 const canonicalUserId = aws.s3.getCanonicalUserId({});
 const productionCanonicalId = canonicalUserId.then(user => user.id);
 const repoDefaultDescription = "Pulumi’s modern infrastructure as code platform empowers cloud engineering teams to work better together to ship faster using the world’s most popular programming languages. Pulumi works with AWS, Kubernetes, and over 50 cloud infrastructure providers."
@@ -413,18 +416,20 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
 
 const cloudfront = new aws.cloudfront.Distribution(`${fullDomain}-cf`, distributionArgs);
 
-const record = new aws.route53.Record(`${fullDomain}-record`, {
-    name: subDomain,
-    type: "A",
-    zoneId: aws.route53.getZone({ name: domain }).then(x => x.zoneId),
-    aliases: [
-        {
-            name: cloudfront.domainName,
-            zoneId: cloudfront.hostedZoneId,
-            evaluateTargetHealth: false,
-        },
-    ],
-});
+if (manageRoute53Record) {
+    new aws.route53.Record(`${fullDomain}-record`, {
+        name: subDomain,
+        type: "A",
+        zoneId: aws.route53.getZone({ name: domain }).then(x => x.zoneId),
+        aliases: [
+            {
+                name: cloudfront.domainName,
+                zoneId: cloudfront.hostedZoneId,
+                evaluateTargetHealth: false,
+            },
+        ],
+    });
+}
 
 // Upload all the files in ../dist. We force the Content-Type header to text/plain, so it renders nicely in a web
 // browser when you view the page directly (for example, to inspect the script).


### PR DESCRIPTION
The production `get.pulumi.com` DNS lives behind Cloudflare (CNAME → `get.pulumi.com.cdn.cloudflare.net`) and is managed out-of-band. The Pulumi program declares an A alias targeting CloudFront directly, so every `pulumi up` against production tries to create a conflicting A record and fails:

```
InvalidChangeBatch: [RRSet of type A with DNS name get.pulumi.com. is not permitted because a conflicting RRSet of type CNAME with the same DNS name already exists in zone pulumi.com.]
```

These changes add a `manageRoute53Record` config option, defaulting to `true` so staging (and any other stacks that exist) keep their current behavior. Production sets it to `false` so the program no longer tries to manage that record.

Staging continues to manage its A alias to CloudFront directly --- it has no Cloudflare in front.

Picks up where #231 and #232 left off. With #231 + the v7 state refresh on staging the `MissingSecurityHeader` is unblocked there; production additionally needed the v7 refresh and this Route53 fix.