### PR TITLE
add Pulumi CLI container for dotnet 10.0

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -184,6 +184,7 @@ const repositoryNames: RepoInfo[] = [
     { name: "pulumi-dotnet-6.0", about: "Pulumi CLI container for dotnet 6.0"},
     { name: "pulumi-dotnet-8.0", about: "Pulumi CLI container for dotnet 8.0"},
     { name: "pulumi-dotnet-9.0", about: "Pulumi CLI container for dotnet 9.0"},
+    { name: "pulumi-dotnet-10.0", about: "Pulumi CLI container for dotnet 10.0"},
     { name: "pulumi-go", about: "Pulumi CLI container for Go"},
     { name: "pulumi-nodejs", about: "Pulumi CLI container for NodeJS"},
     { name: "pulumi-nodejs-18", about: "Pulumi CLI container for NodeJS 18"},


### PR DESCRIPTION
Add pulumi CLI container for the latest dotnet LTS release.  Needs to be applied before https://github.com/pulumi/pulumi-docker-containers/pull/743