### PR TITLE
Bump transitive js-yaml to 3.15.1

### DIFF
--- a/infrastructure/yarn.lock
+++ b/infrastructure/yarn.lock
@@ -1007,9 +1007,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.14.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.2.tgz#77485ce1dd7f33c061fd1b16ecea23b55fcb04b0"
-  integrity sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
Clears the three open Dependabot alerts on this repo, all against the same
transitive `js-yaml` 3.x pin in `infrastructure/yarn.lock` (quadratic-CPU DoS
via merge-key chains and `!!omap` resolution). 3.15.1 satisfies the existing
`^3.13.1` range from `tslint`, so the lockfile pin is the only change; the
separate `js-yaml@^4.3.1` entry is unaffected and not vulnerable.

## Test plan

- `yarn install --frozen-lockfile` in `infrastructure/` succeeds (integrity
  hash verified against the registry).
- `node -p "require('js-yaml/package.json').version"` → `3.15.1`.
- `tsc --noEmit` error count unchanged from master (all pre-existing
  `@types/node` incompatibilities with the pinned TypeScript 3.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)